### PR TITLE
Enable key resets

### DIFF
--- a/eosio.lost.cpp
+++ b/eosio.lost.cpp
@@ -104,7 +104,7 @@ void lostcontract::verify(std::vector<char> sig, name account, public_key newpub
     auto whitelisted = whitelist.get(account.value, "Account is not whitelisted");
 
     auto verification = verifications.find(account.value);
-    eosio_assert(verification == verifications.end(), "Account already verified");
+    eosio_assert(verification == verifications.end() || verification->updated == 0, "Account has already been updated");
 
 
     /////////////////////////
@@ -166,12 +166,20 @@ void lostcontract::verify(std::vector<char> sig, name account, public_key newpub
     eosio_assert( calculated_eth_address == lowercase_whitelist, "Message was not properly signed by the ETH key for the account" );
 
     // Once all checks have passed, store the key change information
-    verifications.emplace(rampayer, [&](verify_info &v){
-        v.claimer  = account;
-        v.added    = time_point_sec(now());
-        v.new_key  = newpubkey;
-        v.updated  = 0;
-    });
+    if (verification == verifications.end()) {
+        verifications.emplace(rampayer, [&](verify_info &v){
+            v.claimer  = account;
+            v.added    = time_point_sec(now());
+            v.new_key  = newpubkey;
+            v.updated  = 0;
+        });
+    } 
+    else {
+        verifications.modify(verification, rampayer, [&](verify_info &v){
+            v.added    = time_point_sec(now());
+            v.new_key  = newpubkey;
+        });
+    }
 
     string msg = "Someone is trying to reset your EOS private key";
     action(permission_level{_self, "active"_n},


### PR DESCRIPTION
This feature would enable users who screwed up their key verifications, to verify again. Every time a user resets their key, it would also reset the thirty day timer. 

For hacked users where two parties possess the ETH private key, both parties would likely go back and forth resetting the keys and the last party to get in a key reset before the contract expiration would "win" the account. 

This would allow hacked users and users who messed up their key verifications to gain access to their accounts without any need for BP arbitration. 